### PR TITLE
URL Bug Fix + QOL Changes (Remember Blocked URLs and Redirect on Disable)

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,18 @@
 function redirectIfBlocked(tab, blockedWebsites) {
-  if (blockedWebsites.some(website => tab.url.includes(website))) {
-    chrome.tabs.update(tab.id, { url: chrome.runtime.getURL("blocked.html") });
+  const tabUrl = new URL(tab.url);
+  const isBlockedSite = blockedWebsites.some((website) =>
+    tabUrl.host.includes(website)
+  );
+
+  if (isBlockedSite) {
+    const blockedUrl = encodeURIComponent(tab.url);
+    const redirectUrl =
+      chrome.runtime.getURL("blocked.html") + "?url=" + blockedUrl;
+
+    chrome.tabs.update(tab.id, { url: redirectUrl });
+  }
+}
+
   }
 }
 

--- a/blocked.html
+++ b/blocked.html
@@ -6,5 +6,7 @@
   <body>
     <h1>This website has been blocked by Focus Blocker</h1>
     <p>You are not allowed to access this website in focus mode.</p>
+    <p><a id="originalUrl" href="#">Go back to the original website</a></p>
+    <script src="blocked.js"></script>
   </body>
 </html>

--- a/blocked.js
+++ b/blocked.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const params = new URLSearchParams(window.location.search);
+    const originalUrl = params.get("url");
+    if (originalUrl) {
+      const decodedUrl = decodeURIComponent(originalUrl);
+      document.getElementById("originalUrl").href = decodedUrl;
+      document.getElementById("originalUrl").textContent = decodedUrl;
+    }
+  });
+  

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Focus Blocker",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "manifest_version": 3,
   "description": "Block certain websites during designated focus times.",
   "action": {


### PR DESCRIPTION
Hey there @suphero ! I love your extension! Your permissions aren't invasive (almost all other extensions like yours have "Read and change anything on all sites" permissions 😱) and your interface is dead simple, I love it!

I decided to try and fix a few things that I think will help with performance, quality of life and also a bug I found.

I tried to make the commit messages as detailed as possible so that what I'm proposing isn't too confusing!

The big changes:

1. **Remembering what URL was blocked.** Now each blocked tab will have the URL passed to it so that when the extension is disabled, those sites will redirect back to their old self.
2. **No longer blocking all open tabs on "Enable".** The reason for this is because with my work-flow, I have 60+ YouTube tabs open that I plan on watching later. Enabling the extension made it redirect _many_ tabs all at once which was troublesome. Now, we only block tabs when they are focused or navigated to!
3. **URL matching was too large.** If an innocent website had a blocked URL's path anywhere in it (e.g. `https://m.example.com:443/news/twitter.com-is-a-site`) then it would get blocked. We now just run the same `.includes()` check but only on the host portion to see if it matches the block list (`m.example.com:443`).

Video of it working in action:

**🔉🔉Be sure to turn sound on! 🔉🔉**

https://github.com/suphero/FocusBlocker/assets/304269/5a6c2e61-5f68-4850-9f3b-6793c217e6bc

